### PR TITLE
Get selected value in an IE8 compatible way.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
@@ -257,7 +257,7 @@ public class Select extends ComplexWidget {
      * and {@link #getValue(int)} for getting all the values selected or {@link #getAllSelectedValues()}
      */
     public String getValue() {
-        return getSelectElement().getValue();
+        return getSelectElement().getOptions().getItem(getSelectElement().getSelectedIndex()).getValue();
     }
 
     public List<String> getAllSelectedValues() {


### PR DESCRIPTION
Here is the basis of the change: http://stackoverflow.com/questions/1721656/unable-to-get-selected-value-from-list-box-in-ie-8
