### PR TITLE
Fixes DateTimeBoxBase reconfiguration.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimeBoxBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimeBoxBase.java
@@ -9,9 +9,9 @@ package org.gwtbootstrap3.extras.datetimepicker.client.ui.base;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -446,6 +446,10 @@ public class DateTimeBoxBase extends Widget implements HasEnabled, HasId, HasRes
 
     protected void configure(final Widget w, final Widget container) {
         w.getElement().setAttribute("data-date-format", format);
+
+        // If configuring not for the first time, datetimepicker must be removed first.
+        this.remove(w.getElement());
+
         configure(w.getElement(), container.getElement(), format, weekStart.getValue(), toDaysOfWeekDisabledString(daysOfWeekDisabled), autoClose,
                 startView.getValue(), minView.getValue(), maxView.getValue(), showTodayButton, highlightToday,
                 keyboardNavigation, forceParse, minuteStep, viewSelect.getValue(), showMeridian, language.getCode());


### PR DESCRIPTION
Before reconfiguring datetimepicker, 'remove' must be invoked first.
