### PR TITLE
ISSUE #36: hour format character mismatch between gwt DateTimeFormat and...

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimeBoxBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimeBoxBase.java
@@ -371,22 +371,27 @@ public class DateTimeBoxBase extends Widget implements HasEnabled, HasId, HasRes
         }
     }
 
-    private void setDateTimeFormat(String format) {
-        // Check http://www.gwtproject.org/javadoc/latest/com/google/gwt/i18n/client/DateTimeFormat.html
-        // for more information on syntax
+	private void setDateTimeFormat(String format) {
+		// Check http://www.gwtproject.org/javadoc/latest/com/google/gwt/i18n/client/DateTimeFormat.html
+		// for more information on syntax
+		Map<Character, Character> map = new HashMap<Character, Character>() {{
+				put('h', 'H'); // 12/24 hours
+				put('H', 'h'); // 12/24 hours
+				put('m', 'M'); // months
+				put('i', 'm'); // minutes
+				put('p', 'a'); // meridian
+				put('P', 'a'); // meridian
+			}};
 
-        // Need to replace m with M for months
-        format = format.replaceAll("m", "M");
+		StringBuilder fb = new StringBuilder(format);
+		for (int i=0; i < fb.length(); i++) {
+			if (map.containsKey(fb.charAt(i))) {
+				fb.setCharAt(i, map.get(fb.charAt(i)));
+			}
+		}
 
-        // Need to replace all i with m for minutes
-        format = format.replaceAll("i", "m");
-
-        // Need to replace P or p with a for meridian
-        format = format.replaceAll("p", "a");
-        format = format.replaceAll("P", "a");
-
-        this.dateTimeFormat = DateTimeFormat.getFormat(format);
-    }
+		this.dateTimeFormat = DateTimeFormat.getFormat(fb.toString());
+	}
 
     public Date getValue() {
         try {


### PR DESCRIPTION
... bootstrap DateTimePicker

added replacement of "h" to "H" and "H" to "h". This could not be done with `.replaceAll`, as the second call would have reverted the change of the first.
Now we iterate over the characters of the string and look them up in the map of discrepancies. Therefore it's safe to "toggle" case, as each character is only processed once, plus it's safer now, as the execution order of `replaceAll`s does not matter anymore.
