### PR TITLE
Allow setting placeholder text on Select

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/select/client/constants/DataAttributes.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/constants/DataAttributes.java
@@ -36,6 +36,7 @@ public class DataAttributes {
     public static final String DATA_WIDTH = "data-width";
     public static final String DATA_MAX_OPTION = "data-max-option";
     public static final String DATA_MOBILE = "data-mobile";
+    public static final String DATA_HIDDEN = "data-hidden";
 
     public static final String DISABLED = "disabled";
     public static final String MULTIPLE = "multiple";

--- a/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Option.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Option.java
@@ -96,4 +96,16 @@ public class Option extends AbstractTextWidget {
     public IconType getIcon() {
         return IconType.fromStyleName(attributeMixin.getAttribute(DATA_ICON));
     }
+    
+    public void setHidden(final boolean hidden) {
+        if (hidden) {
+            attributeMixin.setAttribute(DATA_HIDDEN, Boolean.toString(true));
+        } else {
+            attributeMixin.removeAttribute(DATA_HIDDEN);
+        }
+    }
+    
+    public boolean isHidden() {
+        return attributeMixin.getAttribute(DATA_HIDDEN) != null;
+    }
 }


### PR DESCRIPTION
As per silviomoreto/bootstrap-select#121, this allows a Select that doesn't have a value (by default, the first `Option` is selected) and a placeholder text (set via `title` on `Select`).
