### PR TITLE
Don't load the source map for Bootstrap Select.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/select/client/SelectClientBundle.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/SelectClientBundle.java
@@ -34,9 +34,6 @@ public interface SelectClientBundle extends ClientBundle {
     @Source("resource/js/bootstrap-select.min.js")
     TextResource selectJs();
 	
-	@Source("resource/js/bootstrap-select.js.map")
-    TextResource selectMap();
-
     @Source("resource/js/locales/defaults-cs_CZ.min.js")
     TextResource cs();
 

--- a/src/main/java/org/gwtbootstrap3/extras/select/client/SelectEntryPoint.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/SelectEntryPoint.java
@@ -30,8 +30,6 @@ public class SelectEntryPoint implements EntryPoint {
 
     @Override
     public void onModuleLoad() {
-    	ScriptInjector.fromString(SelectClientBundle.INSTANCE.selectMap().getText()).setWindow(ScriptInjector.TOP_WINDOW)
-                .inject();
         ScriptInjector.fromString(SelectClientBundle.INSTANCE.selectJs().getText()).setWindow(ScriptInjector.TOP_WINDOW)
                 .inject();
     }


### PR DESCRIPTION
Fix an issue introduced in gwtbootstrap3/gwtbootstrap3-extras/pull/97
A source map for Bootstrap Select is getting injected along with the JavaScript file. Unless I'm missing something, this is useless to the end user and just adds additional kBs to download.

I've left the source map in the repository in case a developer would want to use it.. but, honestly, I don't have experience with them, so I'm not sure if the source map should be left there.
