### PR TITLE
Unnecessary logging

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -371,12 +371,7 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
      * @param revertFunction
      */
     public native void excecuteFunction(JavaScriptObject revertFunction)/*-{
-        try {
-            var a = revertFunction;
-            a();
-        }
-        catch (err) {
-            console.log(err);
-        }
+        var a = revertFunction;
+        a();
     }-*/;
 }

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -174,7 +174,6 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
                 $wnd.jQuery.extend(fullCalendarParams, options[i]);
             }
         }
-        console.log(fullCalendarParams);
         $wnd.jQuery('#' + id).fullCalendar(fullCalendarParams);
     }-*/;
 

--- a/src/main/java/org/gwtbootstrap3/extras/growl/client/ui/GrowlOptions.java
+++ b/src/main/java/org/gwtbootstrap3/extras/growl/client/ui/GrowlOptions.java
@@ -82,7 +82,6 @@ public class GrowlOptions extends JavaScriptObject {
     }
 
     private native void setDefaultOptions(JavaScriptObject go) /*-{
-        console.log(go);
         $wnd.jQuery.growl.default_options = go;
     }-*/;
 


### PR DESCRIPTION
This removes all console.log calls. The first reason is because IE 8 does not have console.log defined by default and secondly because we shouldn't have to call that. The developer should do that himself if he needs to.