### PR TITLE
Use namespaced events and proper parameters in ToggleSwitch.switchInit.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
@@ -346,14 +346,13 @@ public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasVa
         $wnd.jQuery(e).bootstrapSwitch();
 
         var me = this;
-        $wnd.jQuery(e).on('switchChange', function (em, data) {
-            me.@org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase::onChange(Z)(data.value);
+        $wnd.jQuery(e).on('switchChange.bootstrapSwitch', function (em, state) {
+            me.@org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase::onChange(Z)(state);
         });
-
     }-*/;
 
     private native void switchDestroy(Element e) /*-{
-        $wnd.jQuery(e).off('switchChange');
+        $wnd.jQuery(e).off('switchChange.bootstrapSwitch');
         $wnd.jQuery(e).bootstrapSwitch('destroy');
     }-*/;
 


### PR DESCRIPTION
As can be seen in the documentation (http://www.bootstrap-switch.org/events.html), there were some changes in the `switchChange` event that I did not take into consideration when upgrading Bootstrap Switch (namespaced event + the parameter is passed with the event is the value, not an object). This commit fixes this regression - ValueChangeEvent is now triggered as before the update.