### PR TITLE
Fix a nullPointerException when there is no value selected.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
@@ -327,7 +327,8 @@ public class Select extends ComplexWidget implements Focusable, HasEnabled, HasL
      * and {@link #getValue(int)} for getting all the values selected or {@link #getAllSelectedValues()}
      */
     public String getValue() {
-        return getSelectElement().getOptions().getItem(getSelectElement().getSelectedIndex()).getValue();
+        int selectedIndex = getSelectElement().getSelectedIndex();
+        return selectedIndex == -1 ? null : getSelectElement().getOptions().getItem(selectedIndex).getValue();
     }
 
     public List<String> getAllSelectedValues() {


### PR DESCRIPTION
In the select, if you call getValue() with no value selected, it will throw a NullPointerException.

getSelectedIndex() will return -1 and getItem(selectedIndex) will return null, thus .getValue() throwing a NullPointerException.