### PR TITLE
Providing support for Paste-Event & possibility of Handler Registration

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/summernote/client/event/SummernoteOnPasteEvent.java
+++ b/src/main/java/org/gwtbootstrap3/extras/summernote/client/event/SummernoteOnPasteEvent.java
@@ -1,0 +1,67 @@
+package org.gwtbootstrap3.extras.summernote.client.event;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.event.shared.GwtEvent;
+import com.google.gwt.user.client.Event;
+import org.gwtbootstrap3.extras.summernote.client.ui.base.SummernoteBase;
+
+
+
+/**
+ * @author martin.matthias
+ */
+public class SummernoteOnPasteEvent extends GwtEvent<SummernoteOnPasteHandler> implements SummernoteEvent {
+
+    private static final Type<SummernoteOnPasteHandler> TYPE = new Type<SummernoteOnPasteHandler>();
+
+    private final SummernoteBase summernote;
+    private final Event nativeEvent;
+
+    public static Type<SummernoteOnPasteHandler> getType() {
+        return TYPE;
+    }
+
+    public SummernoteOnPasteEvent(final SummernoteBase summernote, final Event nativeEvent) {
+        this.summernote = summernote;
+        this.nativeEvent = nativeEvent;
+    }
+
+    @Override
+    public SummernoteBase getSummernote() {
+        return summernote;
+    }
+
+    @Override
+    public Event getNativeEvent() {
+        return nativeEvent;
+    }
+
+    @Override
+    public Type<SummernoteOnPasteHandler> getAssociatedType() {
+        return TYPE;
+    }
+
+    @Override
+    protected void dispatch(final SummernoteOnPasteHandler handler) {
+        handler.onPaste(this);
+    }
+}

--- a/src/main/java/org/gwtbootstrap3/extras/summernote/client/event/SummernoteOnPasteHandler.java
+++ b/src/main/java/org/gwtbootstrap3/extras/summernote/client/event/SummernoteOnPasteHandler.java
@@ -1,0 +1,32 @@
+package org.gwtbootstrap3.extras.summernote.client.event;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.event.shared.EventHandler;
+
+
+
+/**
+ * @author martin.matthias
+ */
+public interface SummernoteOnPasteHandler extends EventHandler {
+    void onPaste(SummernoteOnPasteEvent event);
+}

--- a/src/main/java/org/gwtbootstrap3/extras/summernote/client/ui/base/SummernoteBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/summernote/client/ui/base/SummernoteBase.java
@@ -90,6 +90,10 @@ public class SummernoteBase extends TextArea {
         return addHandler(handler, SummernoteOnKeyUpEvent.getType());
     }
 
+    public HandlerRegistration addPasteHandler(final SummernoteOnPasteHandler handler) {
+        return addHandler(handler, SummernoteOnPasteEvent.getType());
+    }
+
     /**
      * Gets the HTML code generated from the editor
      *
@@ -173,6 +177,10 @@ public class SummernoteBase extends TextArea {
         fireEvent(new SummernoteOnKeyDownEvent(this, evt));
     }
 
+    protected void onPaste(final Event evt) {
+        fireEvent(new SummernoteOnPasteEvent(this, evt));
+    }
+
     private native void initialize(Element e, int height, boolean hasFocus, JavaScriptObject toolbar) /*-{
         var target = this;
 
@@ -200,6 +208,9 @@ public class SummernoteBase extends TextArea {
             },
             onImageUpload: function (evt) {
                 target.@org.gwtbootstrap3.extras.summernote.client.ui.base.SummernoteBase::onImageUpload(Lcom/google/gwt/user/client/Event;)(evt);
+            },
+            onpaste: function (evt) {
+                target.@org.gwtbootstrap3.extras.summernote.client.ui.base.SummernoteBase::onPaste(Lcom/google/gwt/user/client/Event;)(evt);
             }
         });
     }-*/;
@@ -214,6 +225,7 @@ public class SummernoteBase extends TextArea {
         $wnd.jQuery(e).off('onkeyup');
         $wnd.jQuery(e).off('ononkeydowninit');
         $wnd.jQuery(e).off('onImageUpload');
+        $wnd.jQuery(e).off('onpaste');
     }-*/;
 
     private native void setCode(Element e, String code) /*-{


### PR DESCRIPTION
Summernote already provides support for onpaste event. Adding this support to the GWT-Wrapper.