### PR TITLE
FullCalendar support for select and unselect callbacks

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/CalendarConfig.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/CalendarConfig.java
@@ -33,6 +33,7 @@ public class CalendarConfig {
     private Language langauge;//http://arshaw.com/fullcalendar/docs/text/lang/
 
     private ClickAndHoverConfig clickHoverConfig;//http://arshaw.com/fullcalendar/docs/mouse/
+    private SelectConfig selectConfig;//http://arshaw.com/fullcalendar/docs/selection/
     private DragAndResizeConfig dragResizeConfig;//http://arshaw.com/fullcalendar/docs/event_ui/;
     private EventDataConfig eventConfig;//http://arshaw.com/fullcalendar/docs/event_data/
     private GeneralDisplay generalDisplay;//http://arshaw.com/fullcalendar/docs/display/
@@ -171,6 +172,14 @@ public class CalendarConfig {
     public void setClickHoverConfig(final ClickAndHoverConfig clickHoverConfig) {
         this.clickHoverConfig = clickHoverConfig;
     }
+    
+    public SelectConfig getSelectConfig() {
+        return selectConfig;
+    }
+
+    public void setSelectConfig(final SelectConfig selectConfig) {
+        this.selectConfig = selectConfig;
+    }
 
     public DragAndResizeConfig getDragResizeConfig() {
         return dragResizeConfig;
@@ -209,6 +218,7 @@ public class CalendarConfig {
         setParameter(params, getDayNames());
         setParameter(params, getDragResizeConfig());
         setParameter(params, getClickHoverConfig());
+        setParameter(params, getSelectConfig());
         setParameter(params, getEventConfig());
         setParameter(params, getColumnFormat());
         setParameter(params, getTimeFormat());

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/Event.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/Event.java
@@ -93,9 +93,9 @@ public class Event implements IsJavaScriptObject {
     }
 
     private native void setStart(String start) /*-{
-		var theInstance = this;
-    	theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.start = start;
-	}-*/;
+        var theInstance = this;
+        theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.start = start;
+    }-*/;
 
     public native void setStart(final JavaScriptObject start) /*-{
         var theInstance = this;

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/Event.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/Event.java
@@ -93,6 +93,11 @@ public class Event implements IsJavaScriptObject {
     }
 
     private native void setStart(String start) /*-{
+		var theInstance = this;
+    	theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.start = start;
+	}-*/;
+
+    public native void setStart(final JavaScriptObject start) /*-{
         var theInstance = this;
         theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.start = start;
     }-*/;
@@ -131,6 +136,11 @@ public class Event implements IsJavaScriptObject {
     }
 
     private native void setEnd(String end) /*-{
+        var theInstance = this;
+        theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.end = end;
+    }-*/;
+
+    public native void setEnd(final JavaScriptObject end) /*-{
         var theInstance = this;
         theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.Event::event.end = end;
     }-*/;

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -376,7 +376,7 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
     
     public void unselect() {
         unselect(getElement().getId());
-	}
+    }
     
     private native void unselect(String id) /*-{
         $wnd.jQuery('#' + id).fullCalendar('unselect');

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -373,4 +373,12 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
     public native void excecuteFunction(JavaScriptObject revertFunction)/*-{
         revertFunction();
     }-*/;
+    
+    public void unselect() {
+        unselect(getElement().getId());
+	}
+    
+    private native void unselect(String id) /*-{
+        $wnd.jQuery('#' + id).fullCalendar('unselect');
+    }-*/;
 }

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/SelectConfig.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/SelectConfig.java
@@ -1,0 +1,55 @@
+package org.gwtbootstrap3.extras.fullcalendar.client.ui;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.core.client.JavaScriptObject;
+
+/**
+ * Wraps selection events inside a <code>JavaScriptObject</code>
+ *
+ * @see http://fullcalendar.io/docs/selection/
+ */
+public class SelectConfig implements IsJavaScriptObject {
+    private JavaScriptObject script;
+
+    public SelectConfig(final SelectEventCallback handler) {
+        if (handler != null) {
+            newInstance(handler);
+        }
+    }
+
+    private native void newInstance(SelectEventCallback handler) /*-{
+        var theInstance = this;
+        var mouseHandler = handler;
+        theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.SelectConfig::script = {};
+        theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.SelectConfig::script.select = function (start, end, jsEvent, view) {
+            mouseHandler.@org.gwtbootstrap3.extras.fullcalendar.client.ui.SelectEventCallback::select(Lcom/google/gwt/core/client/JavaScriptObject;Lcom/google/gwt/core/client/JavaScriptObject;Lcom/google/gwt/dom/client/NativeEvent;Lcom/google/gwt/core/client/JavaScriptObject;)(start, end, jsEvent, view);
+        };
+        theInstance.@org.gwtbootstrap3.extras.fullcalendar.client.ui.SelectConfig::script.unselect = function (view, jsEvent) {
+            mouseHandler.@org.gwtbootstrap3.extras.fullcalendar.client.ui.SelectEventCallback::unselect(Lcom/google/gwt/core/client/JavaScriptObject;Lcom/google/gwt/dom/client/NativeEvent;)(view, jsEvent);
+        };
+    }-*/;
+
+    @Override
+    public JavaScriptObject toJavaScript() {
+        return script;
+    }
+}

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/SelectEventCallback.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/SelectEventCallback.java
@@ -1,0 +1,34 @@
+package org.gwtbootstrap3.extras.fullcalendar.client.ui;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.google.gwt.core.client.JavaScriptObject;
+import com.google.gwt.dom.client.NativeEvent;
+
+/**
+ * Selection callback interface
+ *
+ */
+public interface SelectEventCallback {
+    public void select(JavaScriptObject start, JavaScriptObject end, NativeEvent event, JavaScriptObject viewObject);
+    
+    public void unselect(JavaScriptObject viewObject, NativeEvent event);
+}

--- a/src/main/resources/org/gwtbootstrap3/extras/fullcalendar/FullCalendar.gwt.xml
+++ b/src/main/resources/org/gwtbootstrap3/extras/fullcalendar/FullCalendar.gwt.xml
@@ -24,4 +24,5 @@
 <module>
     <inherits name="com.google.gwt.user.User"/>
     <source path="client"/>
+    <entry-point class="org.gwtbootstrap3.extras.fullcalendar.client.FullCalendarEntryPoint"/>
 </module>


### PR DESCRIPTION
Clicking into an empty slot in the calendar creates a selection that looks like a draft calendar event. It would be useful to retrieve the start and end date of this selection, for example in order to create a new calendar event in the selected slot. This should be possible by wrapping the function described in the documentation of the original javascript library: http://fullcalendar.io/docs/selection/

I have posted to the google group but have not received any feedback there, so proposing this fully backwards compatible change here. 

I have tried to keep this along the lines of the existing implementation of the ClickAndHoverConfig, please let me know your thoughts.

