### PR TITLE
Added method for setting date format using GWT notation.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
@@ -432,6 +432,59 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasId, Has
         this.weekStart = weekStart;
     }
 
+    /**
+     * Convert GWT date format to bootstrap date format
+     * 
+     * @param format date format using GWT notation
+     * @return date format using bootstrap notation
+     */
+    private static String toBootstrapDateFormat(final String format) {
+        String bootstrap_format = format;
+        
+        // Replace long day name "EEEE" with "DD"
+        bootstrap_format = bootstrap_format.replace("EEEE", "DD");
+        // Replace short day name "EE" with "DD"
+        bootstrap_format = bootstrap_format.replaceAll("E{1,3}", "D");
+        // If there are at least 3 Ms there is month name in wording
+        if (bootstrap_format.contains("MMM")) {
+            // Replace long date month "MMMM" with "MM"
+            bootstrap_format = bootstrap_format.replace("MMMM", "MM");
+            // Replace month name "MMM" with "M"
+            bootstrap_format = bootstrap_format.replace("MMM", "M");
+        }
+        else {
+            // Replace month number with leading 0 "MM" with "mm"
+            bootstrap_format = bootstrap_format.replace("MM", "mm");
+            // Replace month number "M" with "m"
+            bootstrap_format = bootstrap_format.replace("M", "m");
+        }
+        if (!bootstrap_format.contains("yy")) {
+            // Replace full year format "y" with "yyyy"
+            bootstrap_format = bootstrap_format.replace("y", "yyyy");
+        }
+        
+        return bootstrap_format;
+    }
+    
+    /**
+     * Sets format of the date using GWT notation
+     * 
+     * @param format date format in GWT notation
+     */
+    public void setGWTFormat(final String format) {
+        this.format = toBootstrapDateFormat(format);
+
+        // Get the old value
+        final Date oldValue = getValue();
+
+        // Make the new DateTimeFormat
+        this.dateTimeFormat = DateTimeFormat.getFormat(format);
+
+        if (oldValue != null) {
+            setValue(oldValue);
+        }
+    }
+
     @Override
     public void setFormat(final String format) {
         this.format = format;


### PR DESCRIPTION
Hi,

I have extended DateTimePicker component with ability to set date format using GWT notation.

Bootstrap and GWT have different notations for setting date format. Currently data picker supported only setting format using bootstrap notation. For sure this keep component usage compatible with original component.

However, if this component is used within GWT environment, it is very cumbersome to always convert GWT format into bootstrap format; in some situation this can lead to very poor results or bad display of date. In our project we need date support for different date format, so I have added method for setting format using GWT notation. Internally this format is converted into bootstrap notation.

So far I have tested with en_US and sr_RS locales, using long and full date format and it works correctly.

Regards,
Marko

