### PR TITLE
Fixes ToggleSwitch inconsistent return of getValue() method.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
@@ -2,7 +2,7 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui;
 
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase;
 
-import com.google.gwt.user.client.ui.SimpleCheckBox;
+import com.google.gwt.dom.client.Document;
 
 /*
  * #%L
@@ -30,7 +30,7 @@ import com.google.gwt.user.client.ui.SimpleCheckBox;
 public class ToggleSwitch extends ToggleSwitchBase {
 
     public ToggleSwitch() {
-        super(new SimpleCheckBox());
+        super(Document.get().createCheckInputElement());
     }
     
 }

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
@@ -2,7 +2,7 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui;
 
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase;
 
-import com.google.gwt.dom.client.Document;
+import com.google.gwt.user.client.ui.SimpleCheckBox;
 
 /*
  * #%L
@@ -30,7 +30,7 @@ import com.google.gwt.dom.client.Document;
 public class ToggleSwitch extends ToggleSwitchBase {
 
     public ToggleSwitch() {
-        super(Document.get().createCheckInputElement());
+        super(new SimpleCheckBox());
     }
     
 }

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitch.java
@@ -2,7 +2,7 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui;
 
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase;
 
-import com.google.gwt.user.client.ui.SimpleCheckBox;
+import com.google.gwt.dom.client.Document;
 
 /*
  * #%L
@@ -30,6 +30,7 @@ import com.google.gwt.user.client.ui.SimpleCheckBox;
 public class ToggleSwitch extends ToggleSwitchBase {
 
     public ToggleSwitch() {
-        super(new SimpleCheckBox());
+        super(Document.get().createCheckInputElement());
     }
+    
 }

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitchRadio.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitchRadio.java
@@ -20,16 +20,15 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui;
  * #L%
  */
 
+import org.gwtbootstrap3.client.ui.SimpleRadioButton;
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase;
 
-import com.google.gwt.dom.client.Document;
 import com.google.gwt.uibinder.client.UiConstructor;
 
 public class ToggleSwitchRadio extends ToggleSwitchBase {
 
     @UiConstructor
     public ToggleSwitchRadio(String name) {
-        super(Document.get().createRadioInputElement(name));
+        super(new SimpleRadioButton(name));
     }
-    
 }

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitchRadio.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/ToggleSwitchRadio.java
@@ -20,15 +20,16 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui;
  * #L%
  */
 
-import org.gwtbootstrap3.client.ui.SimpleRadioButton;
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.ToggleSwitchBase;
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.uibinder.client.UiConstructor;
 
 public class ToggleSwitchRadio extends ToggleSwitchBase {
 
     @UiConstructor
     public ToggleSwitchRadio(String name) {
-        super(new SimpleRadioButton(name));
+        super(Document.get().createRadioInputElement(name));
     }
+    
 }

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
@@ -217,7 +217,7 @@ public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasVa
      * @param value the changed value.
      */
     public void onChange(final boolean value) {
-        ValueChangeEvent.fire(ToggleSwitchBase.this, value);
+        ValueChangeEvent.fire(this, value);
     }
     
     @Override

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
@@ -20,16 +20,6 @@ package org.gwtbootstrap3.extras.toggleswitch.client.ui.base;
  * #L%
  */
 
-import com.google.gwt.dom.client.Element;
-import com.google.gwt.editor.client.IsEditor;
-import com.google.gwt.editor.client.LeafValueEditor;
-import com.google.gwt.editor.client.adapters.TakesValueEditor;
-import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
-import com.google.gwt.event.logical.shared.ValueChangeEvent;
-import com.google.gwt.event.logical.shared.ValueChangeHandler;
-import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.*;
-
 import org.gwtbootstrap3.client.ui.Icon;
 import org.gwtbootstrap3.client.ui.base.HasId;
 import org.gwtbootstrap3.client.ui.base.HasResponsiveness;
@@ -43,6 +33,21 @@ import org.gwtbootstrap3.client.ui.constants.IconType;
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.constants.ColorType;
 import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.constants.SizeType;
 
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.dom.client.InputElement;
+import com.google.gwt.editor.client.IsEditor;
+import com.google.gwt.editor.client.LeafValueEditor;
+import com.google.gwt.editor.client.adapters.TakesValueEditor;
+import com.google.gwt.event.logical.shared.HasValueChangeHandlers;
+import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
+import com.google.gwt.user.client.ui.HasEnabled;
+import com.google.gwt.user.client.ui.HasName;
+import com.google.gwt.user.client.ui.HasValue;
+import com.google.gwt.user.client.ui.HasVisibility;
+import com.google.gwt.user.client.ui.Widget;
+
 /**
  * Original source from http://www.bootstrap-switch.org/
  * @author Grant Slender
@@ -50,7 +55,6 @@ import org.gwtbootstrap3.extras.toggleswitch.client.ui.base.constants.SizeType;
 public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasValue<Boolean>, HasValueChangeHandlers<Boolean>,
         HasEnabled, HasVisibility, HasId, HasName, HasResponsiveness, IsEditor<LeafValueEditor<Boolean>> {
 
-    private final SimpleCheckBox checkBox;
     private SizeType size = SizeType.REGULAR;
     private ColorType onColor = ColorType.DEFAULT;
     private ColorType offColor = ColorType.PRIMARY;
@@ -58,11 +62,8 @@ public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasVa
     private final AttributeMixin<ToggleSwitchBase> attributeMixin = new AttributeMixin<ToggleSwitchBase>(this);
     private LeafValueEditor<Boolean> editor;
 
-    protected ToggleSwitchBase(SimpleCheckBox checkBox) {
-        this.checkBox = checkBox;
-        // remove the gwt styles
-        checkBox.setStyleName("");
-        setElement((Element) checkBox.getElement());
+    protected ToggleSwitchBase(Element element) {
+        setElement(element);
     }
 
     @Override
@@ -99,12 +100,12 @@ public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasVa
     
     @Override
     public void setName(String name) {
-        checkBox.setName(name);
+        ((InputElement)getElement().cast()).setName(name);
     }
 
     @Override
     public String getName() {
-        return checkBox.getName();
+        return ((InputElement)getElement().cast()).getName();
     }
 
     @Override

--- a/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/toggleswitch/client/ui/base/ToggleSwitchBase.java
@@ -193,77 +193,33 @@ public class ToggleSwitchBase extends Widget implements HasSize<SizeType>, HasVa
         return addHandler(handler, ValueChangeEvent.getType());
     }
 
-    /**
-     * Gets the value of this widget.
-     * 
-     * return the value of the undelying {@link CheckBox}.  This is important because the editor's 
-     * {@link #getValue()} method often is called when not attached.
-     */
+    /** inheritedDoc */
     @Override
     public Boolean getValue() {
-        return checkBox.getValue();
+        return switchState(getElement());
     }
 
+    /** inheritedDoc */
     @Override
     public void setValue(final Boolean value) {
         setValue(value, false);
     }
 
-    /**
-     * Called when this widget is attached to the DOM.
-     * 
-     * Here we want to make sure the state of the toggle switch hasn't changed before it was 
-     * attached or re-attached to the DOM.  If the value has changed update the toggle switch 
-     * via {@link #switchState(Element, boolean, boolean)}.
-     */
-    @Override
-    public void onAttach() {
-        super.onAttach();
-        boolean switchValue = switchState(getElement());
-        boolean value = getValue();
-        if (value != switchValue) {
-            switchState(getElement(), value, true);
-        }
-    }
-    
-    /**
-     * Sets the value of this widget.
-     * 
-     * If we are attached to the DOM, simply switch the state of to the new value and  
-     * if there is a switch in state then the onChange method will be called, if necessary, by 
-     * the 'switchChange.bootstrapSwitch' callback.
-     * 
-     * If we are not attached to the DOM, manually call the onChange method to update the value 
-     * of the underlying {@link CheckBox} and fire change events. 
-     */
+    /** inheritedDoc */
     @Override
     public void setValue(final Boolean value, final boolean fireEvents) {
-        if (isAttached()) {
-            switchState(getElement(), value, true);
-        } else {
-            onChange(value, fireEvents);
-        }
+        switchState(getElement(), value, true);
     }
 
+    /**
+     * Called when the state of the switch changes via the 'switchChange.bootstrapSwitch' callback.
+     * 
+     * @param value the changed value.
+     */
     public void onChange(final boolean value) {
-        onChange(value, true);
+        ValueChangeEvent.fire(ToggleSwitchBase.this, value);
     }
     
-    /**
-     * Called when the state of the toggle switch has changed (via the 'switchChange.bootstrapSwitch' 
-     * callback) or when {@link #setValue(Boolean)} is called while this element is not attached to the DOM.
-     * 
-     * @param value the new value of the toggle switch.
-     * @param fireEvents should we fire events?
-     */
-    public void onChange(final boolean value, boolean fireEvents) {
-        Boolean oldValue = getValue();
-        checkBox.setValue(value);
-        if (fireEvents) {
-            ValueChangeEvent.fireIfNotEqual(ToggleSwitchBase.this, oldValue, value);
-        }
-    }
-
     @Override
     public LeafValueEditor<Boolean> asEditor() {
         if (editor == null) {


### PR DESCRIPTION
The getValue() method returned inconsistent values depending on the isAttached state of the editor.  Often in the editor framework, the getValue and setValue methods will be called when the editor is not attached to the DOM.  The previous implementation only set the underlying checkBox's value when the editor wasn't attached to the DOM.  This means the getValue will return a different value when attached vs not attached.

This implementation uses the checkBox as the underlying authority for the value of the editor and synchronizes its value with the ToggleSwitch when it is attached to the DOM.  If the use toggles the value the underlying checkBox's value is updated.

I also agree with @crevete's comment in #158 that we should rely on the native API when possible but it seems that updating the toggle switch when its not attached to the DOM is problematic.