### PR TITLE
Make sure setCode sets the code variable on initialization.

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/summernote/client/ui/base/SummernoteBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/summernote/client/ui/base/SummernoteBase.java
@@ -254,6 +254,7 @@ public class SummernoteBase extends TextArea {
     }-*/;
 
     private native void setCode(Element e, String code) /*-{
+        this.@org.gwtbootstrap3.extras.summernote.client.ui.base.SummernoteBase::setCode(Ljava/lang/String;)(code);
         $wnd.jQuery(e).code(code);
     }-*/;
 


### PR DESCRIPTION
Fixes problems with using setValue before the widget is completely initialized.