### PR TITLE
Renamed "maxOption" to "maxOptions"

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/select/client/constants/DataAttributes.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/constants/DataAttributes.java
@@ -4,7 +4,7 @@ package org.gwtbootstrap3.extras.select.client.constants;
  * #%L
  * GwtBootstrap3
  * %%
- * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * Copyright (C) 2013 - 2015 GwtBootstrap3
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ public class DataAttributes {
     public static final String DATA_SHOW_SUBTEXT = "data-show-subtext";
     public static final String DATA_SUBTEXT = "data-subtext";
     public static final String DATA_WIDTH = "data-width";
-    public static final String DATA_MAX_OPTION = "data-max-option";
+    public static final String DATA_MAX_OPTIONS = "data-max-options";
     public static final String DATA_MOBILE = "data-mobile";
     public static final String DATA_HIDDEN = "data-hidden";
 

--- a/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
+++ b/src/main/java/org/gwtbootstrap3/extras/select/client/ui/Select.java
@@ -181,16 +181,16 @@ public class Select extends ComplexWidget implements Focusable, HasEnabled, HasL
         return attributeMixin.getAttribute(DATA_WIDTH);
     }
 
-        /**
+    /**
      * Sets the Max Number of selectable option of the select
      * <p/>
      */
-    public void setMaxOption(final String maxOption) {
-        attributeMixin.setAttribute(DATA_MAX_OPTION, maxOption);
+    public void setMaxOptions(final String maxOptions) {
+        attributeMixin.setAttribute(DATA_MAX_OPTIONS, maxOptions);
     }
 
-    public String getMaxOption() {
-        return attributeMixin.getAttribute(DATA_MAX_OPTION);
+    public String getMaxOptions() {
+        return attributeMixin.getAttribute(DATA_MAX_OPTIONS);
     }
 
     public void setShowMenuArrow(final boolean showMenuArrow) {


### PR DESCRIPTION
Fixes #191 : The "maxOption" attribute should be "maxOptions" according to the native
JS library