### PR TITLE
Changed default format to use 24 hour format

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
@@ -153,7 +153,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasId, Has
     /**
      * DEFAULT values
      */
-    private String format = "mm/dd/yyyy HH:ii";
+    private String format = "mm/dd/yyyy hh:ii";
     private DateTimePickerDayOfWeek weekStart = DateTimePickerDayOfWeek.SUNDAY;
     private DateTimePickerDayOfWeek[] daysOfWeekDisabled = {};
     private boolean autoClose = false;
@@ -213,7 +213,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasId, Has
         return textBox.isReadOnly();
     }
 
-    
+
     /** {@inheritDoc} */
     @Override
     public boolean isEnabled() {


### PR DESCRIPTION
The default format was using 12 hour format, while showMeredian is
default of.
This was confusing.