### PR TITLE
fix typo in function name

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -412,12 +412,17 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
         $wnd.jQuery('#' + id).fullCalendar('option', 'aspectRatio', ratio);
     }-*/;
 
+    @Deprecated
+    public native void excecuteFunction(JavaScriptObject revertFunction)/*-{
+        revertFunction();
+    }-*/;
+
     /**
      * Useful for callback cancel/revert functions
      *
      * @param revertFunction
      */
-    public native void excecuteFunction(JavaScriptObject revertFunction)/*-{
+    public native void executeFunction(JavaScriptObject revertFunction)/*-{
         revertFunction();
     }-*/;
     

--- a/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
+++ b/src/main/java/org/gwtbootstrap3/extras/fullcalendar/client/ui/FullCalendar.java
@@ -412,11 +412,6 @@ public class FullCalendar extends FlowPanel implements HasLoadHandlers {
         $wnd.jQuery('#' + id).fullCalendar('option', 'aspectRatio', ratio);
     }-*/;
 
-    @Deprecated
-    public native void excecuteFunction(JavaScriptObject revertFunction)/*-{
-        revertFunction();
-    }-*/;
-
     /**
      * Useful for callback cancel/revert functions
      *


### PR DESCRIPTION
I wasn't sure how to handle a typo in the function name, so I:

- deprecated the old one
- created a new one with the proper name

Is that ok?