### PR TITLE
Added Clear Button in DatePicker and DateTimePicker

### DIFF
--- a/src/main/java/org/gwtbootstrap3/extras/datepicker/client/ui/base/DatePickerBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datepicker/client/ui/base/DatePickerBase.java
@@ -61,6 +61,7 @@ import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasLanguage;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasMinView;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasPosition;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasShowTodayButton;
+import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasShowClearButton;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasStartDate;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasStartView;
 import org.gwtbootstrap3.extras.datepicker.client.ui.base.constants.HasViewSelect;
@@ -99,7 +100,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResponsiveness, HasVisibility, HasPlaceholder,
         HasAutoClose, HasDaysOfWeekDisabled, HasEndDate, HasForceParse, HasFormat, HasHighlightToday, HasKeyboardNavigation,
-        HasMinView, HasShowTodayButton, HasStartDate, HasStartView, HasViewSelect, HasWeekStart, HasDateTimePickerHandlers,
+        HasMinView, HasShowTodayButton, HasShowClearButton, HasStartDate, HasStartView, HasViewSelect, HasWeekStart, HasDateTimePickerHandlers,
         HasLanguage, HasName, HasValue<Date>, HasPosition, LeafValueEditor<Date>, HasEditorErrors<Date>, HasErrorHandler,
         HasValidators<Date>, HasBlankValidator<Date> {
 
@@ -154,6 +155,7 @@ public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResp
     private DatePickerMinView minView = DatePickerMinView.DAY;
 
     private boolean showTodayButton = false;
+    private boolean showClearButton = false;
     private boolean highlightToday = false;
     private boolean keyboardNavigation = true;
     private boolean forceParse = true;
@@ -448,6 +450,12 @@ public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResp
 
     /** {@inheritDoc} */
     @Override
+    public void setShowClearButton(boolean showClearbutton) {
+        this.showClearButton = showClearbutton;
+    }
+
+    /** {@inheritDoc} */
+    @Override
     public void setStartDate(final Date startDate) {
         // Has to be in the format DD-MM-YYYY
         setStartDate(startEndDateFormat.format(startDate));
@@ -649,7 +657,7 @@ public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResp
         this.remove(w.getElement());
 
         configure(w.getElement(), container.getElement(), format, weekStart.getValue(), toDaysOfWeekDisabledString(daysOfWeekDisabled), autoClose,
-                startView.getValue(), minView.getValue(), showTodayButton, highlightToday, keyboardNavigation, forceParse, viewSelect.getValue(),
+                startView.getValue(), minView.getValue(), showTodayButton, showClearButton, highlightToday, keyboardNavigation, forceParse, viewSelect.getValue(),
                 language.getCode(), position.getPosition());
     }
 
@@ -696,7 +704,7 @@ public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResp
     }-*/;
 
     protected native void configure(Element e, Element p, String format, int weekStart, String daysOfWeekDisabled, boolean autoClose, int startView,
-                                    int minViewMode, boolean todayBtn, boolean highlightToday, boolean keyboardNavigation, boolean forceParse, int viewSelect, String language,
+                                    int minViewMode, boolean todayBtn, boolean clearBtn, boolean highlightToday, boolean keyboardNavigation, boolean forceParse, int viewSelect, String language,
                                     String orientation) /*-{
 
         if (todayBtn) {
@@ -713,6 +721,7 @@ public class DatePickerBase extends Widget implements HasEnabled, HasId, HasResp
             startView: startView,
             minViewMode: minViewMode,
             todayBtn: todayBtn,
+            clearBtn: clearBtn,
             todayHighlight: highlightToday,
             keyboardNavigation: keyboardNavigation,
             forceParse: forceParse,

--- a/src/main/java/org/gwtbootstrap3/extras/datepicker/client/ui/base/constants/HasShowClearButton.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datepicker/client/ui/base/constants/HasShowClearButton.java
@@ -1,0 +1,33 @@
+package org.gwtbootstrap3.extras.datepicker.client.ui.base.constants;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Boolean, Default: false
+ * <p/>
+ * If true, displays a clear button at the bottom of the datepicker to clear the selected date.
+ * If true, the "Clear" button will clear the currently selected date from the datepicker;
+ *
+ * @author Rishiraj Anand
+ */
+public interface HasShowClearButton {
+    void setShowClearButton(boolean showClearButton);
+}

--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/DateTimePickerBase.java
@@ -66,6 +66,7 @@ import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasMinut
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasPosition;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasShowMeridian;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasShowTodayButton;
+import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasShowClearButton;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasStartDate;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasStartView;
 import org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants.HasViewSelect;
@@ -103,7 +104,7 @@ import com.google.gwt.user.client.ui.Widget;
  */
 public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnly, HasId, HasResponsiveness, HasVisibility,
         HasPlaceholder, HasAutoClose, HasDaysOfWeekDisabled, HasEndDate, HasForceParse, HasFormat, HasHighlightToday,
-        HasKeyboardNavigation, HasMaxView, HasMinuteStep, HasMinView, HasShowMeridian, HasShowTodayButton, HasStartDate,
+        HasKeyboardNavigation, HasMaxView, HasMinuteStep, HasMinView, HasShowMeridian, HasShowTodayButton, HasShowClearButton, HasStartDate,
         HasStartView, HasViewSelect, HasWeekStart, HasDateTimePickerHandlers, HasLanguage, HasName, HasValue<Date>, HasPosition,
         LeafValueEditor<Date>, HasEditorErrors<Date>, HasErrorHandler, HasValidators<Date>, HasBlankValidator<Date> {
 
@@ -149,7 +150,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
     private LeafValueEditor<Date> editor;
     private final ErrorHandlerMixin<Date> errorHandlerMixin = new ErrorHandlerMixin<Date>(this);
     private final DatePickerValidatorMixin validatorMixin = new DatePickerValidatorMixin(this,
-            errorHandlerMixin.getErrorHandler());
+                                                                                         errorHandlerMixin.getErrorHandler());
 
     /**
      * DEFAULT values
@@ -163,6 +164,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
     private DateTimePickerView minView = DateTimePickerView.HOUR;
     private DateTimePickerView maxView = DateTimePickerView.DECADE;
     private boolean showTodayButton = false;
+    private boolean showClearButton = false;
     private boolean highlightToday = false;
     private boolean keyboardNavigation = true;
     private boolean forceParse = true;
@@ -470,6 +472,13 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
 
     /** {@inheritDoc} */
     @Override
+    public void setShowClearButton(final boolean showClearButton) {
+        this.showClearButton = showClearButton;
+    }
+
+
+    /** {@inheritDoc} */
+    @Override
     public void setStartDate(final Date startDate) {
         // Has to be in the format YYYY-MM-DD
         setStartDate(startEndDateFormat.format(startDate));
@@ -602,7 +611,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
 
     /**
      * Sets the format view type.
-     * 
+     *
      * @param formatViewType
      * @see DateTimePickerFormatViewType
      */
@@ -676,8 +685,8 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
         this.remove(getElement());
 
         configure(getElement(), format, formatViewType.getValue(), weekStart.getValue(), toDaysOfWeekDisabledString(daysOfWeekDisabled),
-                autoClose, startView.getValue(), minView.getValue(), maxView.getValue(), showTodayButton, highlightToday,
-                keyboardNavigation, forceParse, minuteStep, viewSelect.getValue(), showMeridian, language.getCode(), position.getPosition());
+                  autoClose, startView.getValue(), minView.getValue(), maxView.getValue(), showTodayButton, showClearButton, highlightToday,
+                  keyboardNavigation, forceParse, minuteStep, viewSelect.getValue(), showMeridian, language.getCode(), position.getPosition());
     }
 
     protected void execute(final String cmd) {
@@ -717,9 +726,9 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
     }-*/;
 
     protected native void configure(Element e, String format, String formatViewType, int weekStart,
-            String daysOfWeekDisabled, boolean autoClose, int startView, int minView, int maxView, boolean todayBtn, 
-            boolean highlightToday, boolean keyboardNavigation, boolean forceParse, int minuteStep, int viewSelect,
-            boolean showMeridian, String language, String position) /*-{
+                                    String daysOfWeekDisabled, boolean autoClose, int startView, int minView, int maxView, boolean todayBtn, boolean clearBtn,
+                                    boolean highlightToday, boolean keyboardNavigation, boolean forceParse, int minuteStep, int viewSelect,
+                                    boolean showMeridian, String language, String position) /*-{
         var that = this;
         $wnd.jQuery(e).datetimepicker({
             format: format,
@@ -732,6 +741,7 @@ public class DateTimePickerBase extends Widget implements HasEnabled, HasReadOnl
             minView: minView,
             maxView: maxView,
             todayBtn: todayBtn,
+            clearBtn: clearBtn,
             todayHighlight: highlightToday,
             keyboardNavigation: keyboardNavigation,
             forceParse: forceParse,

--- a/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/constants/HasShowClearButton.java
+++ b/src/main/java/org/gwtbootstrap3/extras/datetimepicker/client/ui/base/constants/HasShowClearButton.java
@@ -1,0 +1,33 @@
+package org.gwtbootstrap3.extras.datetimepicker.client.ui.base.constants;
+
+/*
+ * #%L
+ * GwtBootstrap3
+ * %%
+ * Copyright (C) 2013 - 2014 GwtBootstrap3
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Boolean, Default: false
+ * <p/>
+ * If true, displays a clear button at the bottom of the datetimepicker to clear the current date.
+ * If true, the "Clear" button will clear the currently selected date from the datetimepicker;
+ *
+ * @author Rishiraj Anand
+ */
+public interface HasShowClearButton {
+    void setShowClearButton(boolean showClearButton);
+}


### PR DESCRIPTION
- GwtBootstrap currently support bootstrap version 1.5.1, which has a clear button as part of the date picker and datetimepicker. (https://bootstrap-datepicker.readthedocs.io/en/v1.5.1/options.html#clearbtn)
- This button is missing in GwtBootstrap3 v0.9.4. (https://gwtbootstrap3.github.io/gwtbootstrap3-demo/#datePicker).
- All suggestions are welcome, Thank you :)