### PR TITLE
Upgraded bootstrap to version 3.4.1 for fixing XSS vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>org.gwtbootstrap3</groupId>
         <artifactId>gwtbootstrap3-parent</artifactId>
-        <version>0.9.4</version>
+        <version>1.0.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>gwtbootstrap3-extras</artifactId>
-  <version>1.0-SNAPSHOT</version>
+    <version>1.0.1-SNAPSHOT</version>
     <name>GwtBootstrap3 Extras</name>
     <description>Extra, third-party widgets/components for GwtBootstrap3</description>
     <url>http://gwtbootstrap3.org</url>
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>gwtbootstrap3</artifactId>
-            <version>0.9.4</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.gwt</groupId>


### PR DESCRIPTION
- Changed parent version to 1.0.1-SNAPSHOT.
- Corrected version to 1.0.1-SNAPSHOT.

Related PR : https://github.com/gwtbootstrap3/gwtbootstrap3/pull/525